### PR TITLE
Fix flatten issue

### DIFF
--- a/didact.js
+++ b/didact.js
@@ -3,11 +3,13 @@ function createElement(type, props, ...children) {
     type,
     props: {
       ...props,
-      children: children.map(child =>
-        typeof child === "object"
-          ? child
-          : createTextElement(child)
-      ),
+      children: children
+        .flat()
+        .map(child =>
+          typeof child === "object"
+            ? child
+            : createTextElement(child)
+        ),
     },
   }
 }


### PR DESCRIPTION
Fix for https://github.com/pomber/didact/issues/11 so jsx like this won't break rendering:

```javascript
<ul>
   {todos.map(todo => <li>{todo.title}</li>)}
</ul>
```

`...children` coerces non array values into an array, but when children is already an array, it incorrectly turns it into an array where the first item is an array.