### PR TITLE
fix: bug when deleting sibling elements

### DIFF
--- a/didact.js
+++ b/didact.js
@@ -123,6 +123,7 @@ function commitWork(fiber) {
     )
   } else if (fiber.effectTag === "DELETION") {
     commitDeletion(fiber, domParent)
+    return
   }
 
   commitWork(fiber.child)


### PR DESCRIPTION
Since deletions is controlled by "deletions" , commitWork should not be triggered further in the fiber tree for old fibers.