### PR TITLE
fix: dom order

### DIFF
--- a/didact.js
+++ b/didact.js
@@ -121,6 +121,7 @@ function commitWork(fiber) {
       fiber.alternate.props,
       fiber.props
     )
+    domParent.appendChild(fiber.dom)
   } else if (fiber.effectTag === "DELETION") {
     commitDeletion(fiber, domParent)
   }


### PR DESCRIPTION
When an element is updated, it is not moved, so if a previous element is added to the dom (PLACEMENT) the HTML structure doesn't reflect the virtual DOM.

```js
<div/> PLACEMENT // appendChild() place() this element after the updated element
<a/> UPDATE 
<b/>PLACEMENT 
<c/>PLACEMENT
```
This tree will produce the following structure (with the div positionned after the <a/>

```
<a/>  
<div/> 
<b/> 
<c/>
```

