### PR TITLE
Fix "DELETION" exception

### DIFF
--- a/didact.js
+++ b/didact.js
@@ -123,6 +123,7 @@ function commitWork(fiber) {
     )
   } else if (fiber.effectTag === "DELETION") {
     commitDeletion(fiber, domParent)
+    return
   }
 
   commitWork(fiber.child)


### PR DESCRIPTION
`didact` will repeatedly delete child elements, and will throw a exception:

![屏幕快照 2020-10-28 下午8 18 40](https://user-images.githubusercontent.com/19245919/97436249-a7554100-195c-11eb-8bf3-d03a0c875162.png)

See details in [issue 30](https://github.com/pomber/didact/issues/30)