### PR TITLE
feat(useState): allow passing new state directly

### DIFF
--- a/didact.js
+++ b/didact.js
@@ -215,7 +215,7 @@ function useState(initial) {
 
   const actions = oldHook ? oldHook.queue : []
   actions.forEach(action => {
-    hook.state = action(hook.state)
+    hook.state = typeof action === 'function' ? action(hook.state) : action
   })
 
   const setState = action => {


### PR DESCRIPTION
Currently, you need to write a function to setState but this PR allows passing the state value directly just like in React:

```jsx
/** @jsx Didact.createElement */
function Counter() {
  const [state, setState] = Didact.useState(1)

  return (
    <div>
      <p>Count: {state}</p>
      <button onClick={() => setState(c => c - 1)}>Decrement</button>
      <button onClick={() => setState(0)}>Reset</button>
      <button onClick={() => setState(c => c + 1)}>Increment</button>
    </div>
  )
}
const element = <Counter />
const container = document.getElementById("root")
Didact.render(element, container)
```