### PR TITLE
Fix useState to support primitive values in setState

### DIFF
--- a/didact.js
+++ b/didact.js
@@ -219,7 +219,7 @@ function useState(initial) {
   })
 
   const setState = action => {
-    hook.queue.push(action)
+    hook.queue.push(typeof action === "function" ? action : (prev) => action)
     wipRoot = {
       dom: currentRoot.dom,
       props: currentRoot.props,


### PR DESCRIPTION
### Description
Currently, `useState` throws an error when a primitive value (e.g., a number or string) is passed to `setState`. This happens because `setState` expects a function but directly assigns the value, causing an issue when calling `action(hook.state)`.

This fix ensures that primitive values are correctly handled by converting them into a function before storing them in the queue. This makes `useState` behave more like React's implementation.

### Changes
- Updated `setState` to check if `action` is a function.
- If `action` is a primitive value, it is wrapped in a function: `(prev) => action`.
- This prevents errors and aligns `Didact` with React's behavior.

### Before Fix (Throws an Error)
```js
const [count, setCount] = Didact.useState(0);
setCount(1); // ❌ Error: action is not a function
```

### After Fix (Works Correctly)
```js
const [count, setCount] = Didact.useState(0);
setCount(1); // ✅ No error
setCount((prev) => prev + 1); // ✅ Works as expected